### PR TITLE
Extend BlockESP detection range

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -70,6 +70,15 @@ public class BlockESP extends Module {
         .build()
     );
 
+    public final Setting<Integer> distance = sgGeneral.add(new IntSetting.Builder()
+        .name("distance")
+        .description("Chunk distance used to search for blocks. Adds on top of render distance.")
+        .defaultValue(Utils.getRenderDistance() + 1)
+        .min(1)
+        .sliderMax(32)
+        .build()
+    );
+
     private final Setting<Boolean> tracers = sgGeneral.add(new BoolSetting.Builder()
         .name("tracers")
         .description("Render tracer lines.")

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
+import meteordevelopment.meteorclient.systems.modules.Modules;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
@@ -21,6 +22,7 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 import static meteordevelopment.meteorclient.utils.Utils.getRenderDistance;
 
 public class ESPChunk {
+    private static final BlockESP blockEsp = Modules.get().get(BlockESP.class);
 
     private final int x, z;
     public Long2ObjectMap<ESPBlock> blocks;
@@ -72,7 +74,7 @@ public class ESPChunk {
     }
 
     public boolean shouldBeDeleted() {
-        int viewDist = getRenderDistance() + 1;
+        int viewDist = getRenderDistance() + 1 + blockEsp.distance.get();
         int chunkX = ChunkSectionPos.getSectionCoord(mc.player.getBlockPos().getX());
         int chunkZ = ChunkSectionPos.getSectionCoord(mc.player.getBlockPos().getZ());
 


### PR DESCRIPTION
## Summary
- add a new `distance` setting in BlockESP to control how far away chunks are processed
- adjust ESPChunk to respect the new distance setting

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_687e591a71f08320bf6bf212a7c6a204