### PR TITLE
Use constant BlockESP default

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -72,8 +72,8 @@ public class BlockESP extends Module {
 
     public final Setting<Integer> distance = sgGeneral.add(new IntSetting.Builder()
         .name("distance")
-        .description("Chunk distance used to search for blocks. Adds on top of render distance.")
-        .defaultValue(Utils.getRenderDistance() + 1)
+        .description("Additional chunk distance used to search for blocks.")
+        .defaultValue(1)
         .min(1)
         .sliderMax(32)
         .build()


### PR DESCRIPTION
## Summary
- simplify BlockESP distance setting default to a constant

## Testing
- `./gradlew build -x test`
- `./gradlew runClient` *(fails: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_e_687e72ef964c83208434fd1d75a60533