### PR TITLE
Add vertical bounds to BlockESP

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -72,7 +72,7 @@ public class BlockESP extends Module {
 
     public final Setting<Integer> distance = sgGeneral.add(new IntSetting.Builder()
         .name("distance")
-        .description("Additional chunk distance used to search for blocks.")
+        .description("Additional chunk distance used to search for blocks. Also limits vertical culling range in blocks using this value * 16.")
         .defaultValue(1)
         .min(1)
         .sliderMax(32)

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -27,6 +27,9 @@ public class ESPChunk {
     private final int x, z;
     public Long2ObjectMap<ESPBlock> blocks;
 
+    private int bottom = mc.world.getBottomY();
+    private int top = mc.world.getBottomY();
+
     public ESPChunk(int x, int z) {
         this.x = x;
         this.z = z;
@@ -78,7 +81,13 @@ public class ESPChunk {
         int chunkX = ChunkSectionPos.getSectionCoord(mc.player.getBlockPos().getX());
         int chunkZ = ChunkSectionPos.getSectionCoord(mc.player.getBlockPos().getZ());
 
-        return x > chunkX + viewDist || x < chunkX - viewDist || z > chunkZ + viewDist || z < chunkZ - viewDist;
+        boolean horizontal = x > chunkX + viewDist || x < chunkX - viewDist || z > chunkZ + viewDist || z < chunkZ - viewDist;
+
+        int distanceBlocks = blockEsp.distance.get() * 16;
+        int y = mc.player.getBlockPos().getY();
+        boolean vertical = y > top + distanceBlocks || y < bottom - distanceBlocks;
+
+        return horizontal || vertical;
     }
 
     public void render(Render3DEvent event) {
@@ -90,13 +99,20 @@ public class ESPChunk {
 
     public static ESPChunk searchChunk(Chunk chunk, List<Block> blocks) {
         ESPChunk schunk = new ESPChunk(chunk.getPos().x, chunk.getPos().z);
+
+        schunk.bottom = mc.world.getBottomY();
+        schunk.top = mc.world.getHeight();
+
         if (schunk.shouldBeDeleted()) return schunk;
 
         BlockPos.Mutable blockPos = new BlockPos.Mutable();
+        int maxHeight = mc.world.getBottomY();
 
         for (int x = chunk.getPos().getStartX(); x <= chunk.getPos().getEndX(); x++) {
             for (int z = chunk.getPos().getStartZ(); z <= chunk.getPos().getEndZ(); z++) {
                 int height = chunk.getHeightmap(Heightmap.Type.WORLD_SURFACE).get(x - chunk.getPos().getStartX(), z - chunk.getPos().getStartZ());
+
+                if (height > maxHeight) maxHeight = height;
 
                 for (int y = mc.world.getBottomY(); y < height; y++) {
                     blockPos.set(x, y, z);
@@ -106,6 +122,8 @@ public class ESPChunk {
                 }
             }
         }
+
+        schunk.top = maxHeight;
 
         return schunk;
     }


### PR DESCRIPTION
## Summary
- extend BlockESP distance setting description with vertical bound clarification
- track searched vertical range in ESPChunk
- cull ESP chunks using vertical limits based on the distance setting

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687e7b0c40248320b8c38f70f300eb1b