### PR TITLE
Update issue templates and website links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://meteorclient.com/donate']
+custom: ['https://cookieclient.com/donate']

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -27,7 +27,7 @@ body:
   - type: input
     id: meteor-version
     attributes:
-      label: Meteor Version
+      label: Cookie Version
       placeholder: Meteor X.Y.Z (or X.Y.Z-build_number)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discord
-    url: https://meteorclient.com/discord
+    url: https://cookieclient.com/discord
     about: Join our discord for faster support on smaller issues.

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -22,7 +22,7 @@ body:
   - type: input
     id: meteor-version
     attributes:
-      label: Meteor Version
+      label: Cookie Version
       placeholder: Meteor X.Y.Z (or X.Y.Z-build_number)
     validations:
       required: true

--- a/.github/builds/get_number.js
+++ b/.github/builds/get_number.js
@@ -7,7 +7,7 @@ import { getMcVersion } from "./mc_version.js"
 
 const mcVersion = await getMcVersion();
 
-fetch("https://meteorclient.com/api/stats")
+fetch("https://cookieclient.com/api/stats")
     .then(async res => {
         let stats = await res.json()
         let build = 0

--- a/.github/builds/index.js
+++ b/.github/builds/index.js
@@ -32,17 +32,17 @@ function sendDiscordWebhook() {
             if (hasChanges) description += changes;
 
             if (success) {
-                description += "\n\nVisit our [website](https://meteorclient.com) for download";
+                description += "\n\nVisit our [website](https://cookieclient.com) for download";
             }
 
             const webhook = {
                 username: "Builds",
-                avatar_url: "https://meteorclient.com/icon.png",
+                avatar_url: "https://cookieclient.com/icon.png",
                 embeds: [
                     {
                         title: "Cookie Client " + mcVersion + " build #" + buildNumber,
                         description: description,
-                        url: "https://meteorclient.com",
+                        url: "https://cookieclient.com",
                             color: success ? 2672680 : 13117480
                     }
                 ]
@@ -59,7 +59,7 @@ function sendDiscordWebhook() {
 }
 
 if (success) {
-    fetch("https://meteorclient.com/api/recheckMaven", {
+    fetch("https://cookieclient.com/api/recheckMaven", {
         method: "POST",
         headers: {
             "Authorization": process.env.SERVER_TOKEN

--- a/.github/moderation/banned_terms.js
+++ b/.github/moderation/banned_terms.js
@@ -88,7 +88,7 @@ async function run() {
 
     if (checkTerm(issueText, "old version")) {
         const oldVersionMessage =
-            'Our [archive page](https://www.meteorclient.com/archive) stores major Meteor versions for Minecraft ' +
+            'Our [archive page](https://www.cookieclient.com/archive) stores major Meteor versions for Minecraft ' +
             'versions starting at 1.21.4. If you wish to use older builds on older versions of Minecraft, you will ' +
             'need to build them yourself. **You will not receive support for issues with old versions of Meteor!**'
 


### PR DESCRIPTION
## Summary
- replace "Meteor Version" with "Cookie Version" in bug and crash templates
- update all `.github` scripts to use `cookieclient.com` links

## Testing
- `./gradlew build` *(fails: ESPChunk.java errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e864841ac8320b4cf0979a301c159