### PR TITLE
Replace meteor-client links

### DIFF
--- a/.idea/copyright/Cookie.xml
+++ b/.idea/copyright/Cookie.xml
@@ -1,7 +1,7 @@
 <component name="CopyrightManager">
   <copyright>
     <option name="keyword" value="This file is part of the Cookie Client distribution" />
-    <option name="notice" value="This file is part of the Cookie Client distribution (https://github.com/CookieDevelopment/meteor-client).&#10;Copyright (c) Cookie Development." />
+    <option name="notice" value="This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).&#10;Copyright (c) Cookie Development." />
     <option name="myName" value="Cookie" />
   </copyright>
 </component>

--- a/launch/src/main/java/meteordevelopment/meteorclient/Main.java
+++ b/launch/src/main/java/meteordevelopment/meteorclient/Main.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/CookieClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/CookieClient.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
+++ b/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/ModMenuIntegration.java
+++ b/src/main/java/meteordevelopment/meteorclient/ModMenuIntegration.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/addons/CookieAddon.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/CookieAddon.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/addons/GithubRepo.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/GithubRepo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/asm/Asm.java
+++ b/src/main/java/meteordevelopment/meteorclient/asm/Asm.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/asm/AsmTransformer.java
+++ b/src/main/java/meteordevelopment/meteorclient/asm/AsmTransformer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/asm/Descriptor.java
+++ b/src/main/java/meteordevelopment/meteorclient/asm/Descriptor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/asm/FieldInfo.java
+++ b/src/main/java/meteordevelopment/meteorclient/asm/FieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/asm/MethodInfo.java
+++ b/src/main/java/meteordevelopment/meteorclient/asm/MethodInfo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/asm/transformers/PacketInflaterTransformer.java
+++ b/src/main/java/meteordevelopment/meteorclient/asm/transformers/PacketInflaterTransformer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/Command.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Command.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/ComponentMapArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/ComponentMapArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/CompoundNbtTagArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/CompoundNbtTagArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/DirectionArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/DirectionArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/FakePlayerArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/FakePlayerArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/MacroArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/MacroArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/ModuleArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/ModuleArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/NotebotSongArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/NotebotSongArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerListEntryArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerListEntryArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/ProfileArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/ProfileArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/RegistryEntryReferenceArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/RegistryEntryReferenceArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingValueArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingValueArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/WaypointArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/WaypointArgumentType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindsCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/CommandsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/CommandsCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DamageCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DamageCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DisconnectCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DisconnectCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DismountCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DismountCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/EnchantCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/EnchantCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/EnderChestCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/EnderChestCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FakePlayerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FakePlayerCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FovCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FovCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FriendsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FriendsCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/GamemodeCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/GamemodeCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/GiveCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/GiveCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/HClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/HClipCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InventoryCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InventoryCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/LocateCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/LocateCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ModulesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ModulesCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NameHistoryCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NameHistoryCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NotebotCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NotebotCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 
@@ -47,7 +47,7 @@ public class NotebotCommand extends Command {
     @Override
     public void build(LiteralArgumentBuilder<CommandSource> builder) {
         builder.then(literal("help").executes(ctx -> {
-            Util.getOperatingSystem().open("https://github.com/MeteorDevelopment/meteor-client/wiki/Notebot-Guide");
+            Util.getOperatingSystem().open("https://github.com/cookie-client/cookie-client/wiki/Notebot-Guide");
             return SINGLE_SUCCESS;
         }));
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ProfilesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ProfilesCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ResetCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ResetCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/RotationCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/RotationCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SaveMapCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SaveMapCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SayCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SayCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SpectateCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SpectateCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ToggleCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ToggleCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/WaspCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/WaspCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/WaypointCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/WaypointCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/Cancellable.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/Cancellable.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/BoatMoveEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/BoatMoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/DropItemsEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/DropItemsEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/EntityAddedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/EntityAddedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/EntityDestroyEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/EntityDestroyEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/EntityRemovedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/EntityRemovedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/LivingEntityMoveEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/LivingEntityMoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/AttackEntityEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/AttackEntityEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/BlockBreakingCooldownEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/BlockBreakingCooldownEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/BreakBlockEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/BreakBlockEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/CanWalkOnFluidEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/CanWalkOnFluidEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 
@@ -17,7 +17,7 @@ import net.minecraft.fluid.FluidState;
  * calculates whether there is enough space to fit your bounding box if you change into that pose. This method ends up
  * calling {@link LivingEntity#canWalkOnFluid(net.minecraft.fluid.FluidState)}, causing this event to fire
  * again and leading to a stack overflow crash. Introduced in
- * <a href="https://github.com/MeteorDevelopment/meteor-client/pull/5449">this pull request</a>
+ * <a href="https://github.com/cookie-client/cookie-client/pull/5449">this pull request</a>
  */
 public class CanWalkOnFluidEvent {
     private static final CanWalkOnFluidEvent INSTANCE = new CanWalkOnFluidEvent();

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/ClipAtLedgeEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/ClipAtLedgeEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/FinishUsingItemEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/FinishUsingItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/InteractBlockEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/InteractBlockEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/InteractEntityEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/InteractEntityEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/InteractItemEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/InteractItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/ItemUseCrosshairTargetEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/ItemUseCrosshairTargetEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/JumpVelocityMultiplierEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/JumpVelocityMultiplierEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/PickItemsEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/PickItemsEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlaceBlockEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlaceBlockEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlayerMoveEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlayerMoveEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlayerTickMovementEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlayerTickMovementEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/SendMovementPacketsEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/SendMovementPacketsEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/StartBreakingBlockEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/StartBreakingBlockEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/StoppedUsingItemEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/StoppedUsingItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/ChangePerspectiveEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ChangePerspectiveEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/GameJoinedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/GameJoinedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/GameLeftEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/GameLeftEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/ItemStackTooltipEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ItemStackTooltipEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/OpenScreenEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/OpenScreenEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/ReceiveMessageEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ReceiveMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/ResolutionChangedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ResolutionChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/ResourcePacksReloadedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ResourcePacksReloadedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/game/SendMessageEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/SendMessageEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/ActiveModulesChangedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/ActiveModulesChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/CharTypedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/CharTypedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/CustomFontChangedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/CustomFontChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/KeyEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/KeyEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/ModuleBindChangedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/ModuleBindChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/MouseButtonEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/MouseButtonEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/meteor/MouseScrollEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/meteor/MouseScrollEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/packets/ContainerSlotUpdateEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/packets/ContainerSlotUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/packets/InventoryEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/packets/InventoryEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/packets/PacketEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/packets/PacketEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/packets/PlaySoundPacketEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/packets/PlaySoundPacketEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/ApplyTransformationEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/ApplyTransformationEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/ArmRenderEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/ArmRenderEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/GetFovEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/GetFovEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/HeldItemRendererEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/HeldItemRendererEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/Render2DEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/Render2DEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/Render3DEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/Render3DEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/RenderAfterWorldEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/RenderAfterWorldEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/RenderBlockEntityEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/RenderBlockEntityEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/RenderBossBarEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/RenderBossBarEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/RenderItemEntityEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/RenderItemEntityEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/render/TooltipDataEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/TooltipDataEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/AmbientOcclusionEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/AmbientOcclusionEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/BlockActivateEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/BlockActivateEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/BlockUpdateEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/BlockUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/ChunkDataEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ChunkDataEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/ChunkOcclusionEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ChunkOcclusionEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/CollisionShapeEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/CollisionShapeEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/ParticleEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ParticleEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/PlaySoundEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/PlaySoundEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectBeginEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectBeginEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectEndEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectEndEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/events/world/TickEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/TickEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiKeyEvents.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiKeyEvents.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiThemes.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiThemes.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/WindowScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/WindowScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiDebugRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiDebugRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiRenderOperation.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiRenderOperation.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/Scissor.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/Scissor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/operations/TextOperation.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/operations/TextOperation.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/packer/GuiTexture.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/packer/GuiTexture.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/packer/TexturePacker.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/packer/TexturePacker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/packer/TextureRegion.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/packer/TextureRegion.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/CommitsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/CommitsScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/EditBookTitleAndAuthorScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/EditBookTitleAndAuthorScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/MarkerScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/MarkerScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/NotebotSongsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/NotebotSongsScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesImportScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesImportScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AccountInfoScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AccountInfoScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AccountsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AccountsScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAccountScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAlteningAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAlteningAccountScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddCrackedAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddCrackedAccountScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddMicrosoftAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddMicrosoftAccountScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockDataSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockDataSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/CollectionListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/CollectionListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ColorSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ColorSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/DynamicRegistryListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/DynamicRegistryListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EnchantmentListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EnchantmentListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/FontFaceSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/FontFaceSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ModuleListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ModuleListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/PacketBoolSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/PacketBoolSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ParticleTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ParticleTypeListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/PotionSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/PotionSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ScreenHandlerSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ScreenHandlerSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/SoundEventListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/SoundEventListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StorageBlockListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StorageBlockListSettingScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/Tab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/Tab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/TabScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/TabScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/Tabs.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/Tabs.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/WindowTabScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/WindowTabScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ConfigTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ConfigTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/GuiTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/GuiTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/HudTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/HudTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ModulesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ModulesTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/PathManagerTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/PathManagerTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/CookieGuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/CookieGuiTheme.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/CookieWidget.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/CookieWidget.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorAccount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorHorizontalSeparator.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorHorizontalSeparator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorLabel.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorModule.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorMultiLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorMultiLabel.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorQuad.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorQuad.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorSection.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorSection.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorTooltip.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorTooltip.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorTopBar.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorTopBar.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorVerticalSeparator.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorVerticalSeparator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorView.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorView.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorWindow.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorWindow.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorDropdown.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorDropdown.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorSlider.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorSlider.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorTextBox.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorTextBox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorButton.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorCheckbox.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorCheckbox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorFavorite.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorFavorite.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorMinus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorMinus.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorPlus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorPlus.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorTriangle.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorTriangle.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/AlignmentX.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/AlignmentX.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/AlignmentY.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/AlignmentY.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/BaseWidget.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/BaseWidget.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/Cell.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/Cell.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/CharFilter.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/CharFilter.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/IScreenFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/IScreenFactory.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/SettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/SettingsWidgetFactory.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/StarscriptTextBoxRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/StarscriptTextBoxRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/WindowConfig.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/WindowConfig.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WHorizontalSeparator.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WHorizontalSeparator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WItem.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WItem.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WItemWithLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WItemWithLabel.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WKeybind.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WKeybind.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WLabel.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WMultiLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WMultiLabel.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WQuad.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WQuad.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WRoot.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WRoot.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WTexture.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WTexture.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WTooltip.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WTooltip.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WTopBar.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WTopBar.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WVerticalSeparator.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WVerticalSeparator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WWidget.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WWidget.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WContainer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WContainer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WHorizontalList.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WHorizontalList.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WSection.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WSection.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WTable.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WTable.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WVerticalList.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WVerticalList.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WView.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WView.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WWindow.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WWindow.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WBlockPosEdit.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WBlockPosEdit.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDoubleEdit.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDoubleEdit.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDropdown.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDropdown.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WIntEdit.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WIntEdit.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WSlider.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WSlider.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WTextBox.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WTextBox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WButton.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WCheckbox.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WCheckbox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WFavorite.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WFavorite.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WMinus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WMinus.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WPlus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WPlus.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WPressable.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WPressable.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WTriangle.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WTriangle.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBoatEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBoatEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractClientPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractClientPlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractFurnaceScreenHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractFurnaceScreenHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractFurnaceScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractFurnaceScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignBlockEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignBlockEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignEditScreenAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignEditScreenAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignEditScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignEditScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ArmorFeatureRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ArmorFeatureRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BakedQuadMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BakedQuadMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BannerBlockEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BannerBlockEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BeaconBlockEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BeaconBlockEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BeaconScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BeaconScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BiomeColorsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BiomeColorsMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockCollisionSpliteratorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockCollisionSpliteratorMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockColorsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockColorsMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockEntityRenderDispatcherMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockEntityRenderDispatcherMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockEntityTypeAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockEntityTypeAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockHitResultAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockHitResultAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockItemMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockItemMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockModelRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockModelRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockRenderManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockRenderManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockStateMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BookScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BookScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BossBarHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BossBarHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BoxMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BoxMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BrewingStandScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BrewingStandScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BrightnessGetterMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BrightnessGetterMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CameraMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CameraMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CapabilityTrackerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CapabilityTrackerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CapeFeatureRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CapeFeatureRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudLineMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudLineMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudLineVisibleMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudLineVisibleMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChunkAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChunkAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChunkBorderDebugRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChunkBorderDebugRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChunkOcclusionDataBuilderMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChunkOcclusionDataBuilderMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChunkSkyLightProviderMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChunkSkyLightProviderMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientChunkManagerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientChunkManagerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientChunkMapAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientChunkMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientWorldMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientWorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CobwebBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CobwebBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CompassStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CompassStateMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ConnectScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ConnectScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ContainerComponentAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ContainerComponentAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ContainerComponentMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ContainerComponentMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CrashReportMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CrashReportMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CreativeInventoryScreenAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CreativeInventoryScreenAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CreativeSlotMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CreativeSlotMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/CrossbowItemAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/CrossbowItemAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/DefaultSkinHelperMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DefaultSkinHelperMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/DrawContextMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DrawContextMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ElytraFeatureRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ElytraFeatureRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EnchantingTableBlockEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EnchantingTableBlockEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EndCrystalEntityModelMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EndCrystalEntityModelMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EndCrystalEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EndCrystalEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityBucketItemAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityBucketItemAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityRenderDispatcherMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityRenderDispatcherMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityRenderStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityRenderStateMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityTrackingSectionAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityTrackingSectionAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityVelocityUpdateS2CPacketAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityVelocityUpdateS2CPacketAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ExplosionS2CPacketMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ExplosionS2CPacketMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FileCacheAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FileCacheAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FireworkRocketEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FireworkRocketEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FireworksSparkParticleMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FireworksSparkParticleMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FireworksSparkParticleSubMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FireworksSparkParticleSubMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FishingBobberEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FishingBobberEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FluidRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FluidRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/FogRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FogRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameOptionsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameOptionsMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GlBackendMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GlBackendMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GlCommandEncoderMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GlCommandEncoderMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GpuTextureMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GpuTextureMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/HandledScreenAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/HandledScreenAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/HandledScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/HandledScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/HeadFeatureRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/HeadFeatureRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/HeldItemRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/HeldItemRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/HorseScreenHandlerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/HorseScreenHandlerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/IdentifierAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/IdentifierAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/InGameHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/InGameHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/InGameOverlayRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/InGameOverlayRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemGroupsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemGroupsMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/KeyBindingAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/KeyBindingAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/KeyboardInputMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/KeyboardInputMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/KeyboardMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/KeyboardMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LayerRenderStateAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LayerRenderStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LightmapTextureManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LightmapTextureManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LightningEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LightningEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MapRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MapRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MapTextureManagerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MapTextureManagerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MessageHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MessageHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftServerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftServerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MobEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MobEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MobSpawnerBlockEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MobSpawnerBlockEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MouseMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MouseMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiPhaseMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiPhaseMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiPhaseParametersMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiPhaseParametersMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MutableTextMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MutableTextMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PacketByteBufMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PacketByteBufMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ParticleManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ParticleManagerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerInteractEntityC2SPacketMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerInteractEntityC2SPacketMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListEntryMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListEntryMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerMoveC2SPacketAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerMoveC2SPacketAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerMoveC2SPacketMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerMoveC2SPacketMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerSkinProviderAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerSkinProviderAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PowderSnowBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PowderSnowBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ProjectileEntityAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ProjectileEntityAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ProjectileInGroundAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ProjectileInGroundAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ProjectionMatrix2Accessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ProjectionMatrix2Accessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/RaycastContextMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/RaycastContextMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/RegistriesMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/RegistriesMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ReloadStateAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ReloadStateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/RenderLayersMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/RenderLayersMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/RenderPipelineMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/RenderPipelineMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/RenderSystemMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/RenderSystemMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/RenderTickCounterDynamicMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/RenderTickCounterDynamicMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ResourceReloadLoggerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ResourceReloadLoggerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SectionedEntityCacheAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SectionedEntityCacheAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ServerPlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ServerResourcePackLoaderMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ServerResourcePackLoaderMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ShaderLoaderMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ShaderLoaderMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ShapeIndexBufferAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ShapeIndexBufferAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ShulkerBoxScreenHandlerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ShulkerBoxScreenHandlerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SimpleEntityLookupAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SimpleEntityLookupAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SimpleOptionMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SimpleOptionMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SlimeBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SlimeBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SlotMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SlotMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SoundSystemMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SoundSystemMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SplashTextResourceSupplierMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SplashTextResourceSupplierMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/StatusEffectFogModifierMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/StatusEffectFogModifierMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/StatusEffectInstanceAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/StatusEffectInstanceAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/StatusEffectInstanceMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/StatusEffectInstanceMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/StringHelperMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/StringHelperMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/SweetBerryBushBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/SweetBerryBushBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TextHandlerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TextHandlerAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TextMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TextMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TextRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TextRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TextVisitFactoryMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TextVisitFactoryMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TitleScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TitleScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TooltipComponentMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TooltipComponentMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TooltipDisplayComponentMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TooltipDisplayComponentMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TransformationMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TransformationMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/TridentItemMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TridentItemMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/Vec3dMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/Vec3dMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/WorldAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/WorldAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/WorldBorderMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/WorldBorderMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/WorldChunkMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/WorldChunkMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/WorldRendererAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/WorldRendererAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/WorldRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/WorldRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/YggdrasilMinecraftSessionServiceAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/YggdrasilMinecraftSessionServiceAccessor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/baritone/ComeCommandMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/baritone/ComeCommandMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/indigo/AbstractTerrainRenderContextMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/indigo/AbstractTerrainRenderContextMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/lithium/ChunkAwareBlockCollisionSweeperMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/lithium/ChunkAwareBlockCollisionSweeperMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/lithium/LithiumEntityCollisionsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/lithium/LithiumEntityCollisionsMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockOcclusionCacheMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockOcclusionCacheMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererImplDefaultRenderContextMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererImplDefaultRenderContextMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererImplMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererImplMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumLightDataAccessMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumLightDataAccessMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumWorldRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumWorldRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/viafabricplus/GeneralSettingsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/viafabricplus/GeneralSettingsMixin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IAbstractFurnaceScreenHandler.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IAbstractFurnaceScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IBakedQuad.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IBakedQuad.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IBox.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IBox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/ICamera.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/ICamera.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/ICapabilityTracker.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/ICapabilityTracker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IChatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IChatHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IChatHudLine.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IChatHudLine.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IChatHudLineVisible.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IChatHudLineVisible.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IClientPlayerInteractionManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IClientPlayerInteractionManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IEntityRenderState.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IEntityRenderState.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IExplosionS2CPacket.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IExplosionS2CPacket.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IGpuDevice.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IGpuDevice.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IGpuTexture.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IGpuTexture.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IMessageHandler.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IMinecraftClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IMinecraftClient.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IMultiPhase.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IMultiPhase.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IMultiPhaseParameters.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IMultiPhaseParameters.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IPlayerInteractEntityC2SPacket.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IPlayerInteractEntityC2SPacket.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IPlayerMoveC2SPacket.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IPlayerMoveC2SPacket.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IRaycastContext.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IRaycastContext.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IRenderPipeline.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IRenderPipeline.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/ISimpleOption.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/ISimpleOption.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/ISlot.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/ISlot.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IText.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IText.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IVec3d.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IVec3d.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IWorldRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IWorldRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/pathing/BaritonePathManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/BaritonePathManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/pathing/BaritoneSettings.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/BaritoneSettings.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/pathing/BaritoneUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/BaritoneUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/pathing/IPathManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/IPathManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/pathing/NopPathManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/NopPathManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/pathing/PathManagers.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/PathManagers.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/CookieRenderPipelines.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/CookieRenderPipelines.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/CookieVertexFormatElements.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/CookieVertexFormatElements.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/CookieVertexFormats.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/CookieVertexFormats.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/ExtendedRenderPipelineBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/ExtendedRenderPipelineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshUniforms.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshUniforms.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Renderer2D.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Renderer2D.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Renderer3D.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Renderer3D.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/ShapeMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/ShapeMode.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Texture.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Texture.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/FontFamily.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/FontFamily.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/FontInfo.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/FontInfo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/TextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/TextRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/VanillaTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/VanillaTextRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/BlockDataSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/BlockDataSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/BlockListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/BlockListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/BlockPosSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/BlockPosSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/BlockSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/BlockSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/BoolSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/BoolSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ColorListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ColorListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ColorSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ColorSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/DoubleSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/DoubleSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/EnchantmentListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/EnchantmentListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/EntityTypeListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/EntityTypeListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/EnumSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/EnumSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/FontFaceSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/FontFaceSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/GenericSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/GenericSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/IBlockData.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/IBlockData.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/IVisible.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/IVisible.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/IntSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/IntSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ItemListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ItemListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ItemSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ItemSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/KeybindSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/KeybindSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ModuleListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ModuleListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/PacketListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/PacketListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ParticleTypeListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ParticleTypeListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/PotionSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/PotionSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ProvidedStringSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ProvidedStringSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/ScreenHandlerListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ScreenHandlerListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/Setting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/Setting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/SettingGroup.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/SettingGroup.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/Settings.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/Settings.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/SoundEventListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/SoundEventListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectAmplifierMapSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectAmplifierMapSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StorageBlockListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StorageBlockListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StringListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StringListSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/Vector3dSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/Vector3dSetting.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/System.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/System.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/Account.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/Account.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/AccountCache.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/AccountCache.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/AccountType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/AccountType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/Accounts.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/Accounts.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/MicrosoftLogin.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/MicrosoftLogin.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/TexturesJson.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/TexturesJson.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/TokenAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/TokenAccount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/UuidToProfileResponse.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/UuidToProfileResponse.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/CrackedAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/CrackedAccount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/MicrosoftAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/MicrosoftAccount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/TheAlteningAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/TheAlteningAccount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/friends/Friend.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/friends/Friend.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/friends/Friends.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/friends/Friends.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Alignment.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Alignment.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudBox.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudBox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudElement.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudElement.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudElementInfo.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudElementInfo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudGroup.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudGroup.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/XAnchor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/XAnchor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/YAnchor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/YAnchor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CookieTextHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CookieTextHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ModuleInfosHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ModuleInfosHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/TextHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/TextHud.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/AddHudElementScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/AddHudElementScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudEditorScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudEditorScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudElementPresetsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudElementPresetsScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudElementScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudElementScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/macros/Macro.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/macros/Macro.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/macros/Macros.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/macros/Macros.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Categories.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Categories.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Category.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Category.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Module.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Module.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AntiAnchor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AntiAnchor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AntiAnvil.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AntiAnvil.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AntiBed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AntiBed.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/ArrowDodge.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/ArrowDodge.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoAnvil.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoAnvil.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoArmor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoArmor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoCity.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoCity.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoEXP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoEXP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoLog.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoTotem.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoTotem.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoTrap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoTrap.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoWeapon.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoWeapon.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoWeb.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoWeb.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowSpam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowSpam.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Burrow.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Burrow.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/CrystalAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/CrystalAura.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Hitboxes.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Hitboxes.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/HoleFiller.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/HoleFiller.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Quiver.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Quiver.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SelfAnvil.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SelfAnvil.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SelfTrap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SelfTrap.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SelfWeb.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SelfWeb.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Surround.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Surround.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AntiPacketKick.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AntiPacketKick.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterBeacons.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterBeacons.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/DiscordPresence.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/DiscordPresence.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 
@@ -288,7 +288,7 @@ public class DiscordPresence extends Module {
     @Override
     public WWidget getWidget(GuiTheme theme) {
         WButton help = theme.button("Open documentation.");
-        help.action = () -> Util.getOperatingSystem().open("https://github.com/MeteorDevelopment/meteor-client/wiki/Starscript");
+        help.action = () -> Util.getOperatingSystem().open("https://github.com/cookie-client/cookie-client/wiki/Starscript");
 
         return help;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/MessageAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/MessageAura.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/PacketCanceller.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/PacketCanceller.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/SoundBlocker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/SoundBlocker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Spam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Spam.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/Swarm.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/Swarm.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 
@@ -72,7 +72,7 @@ public class Swarm extends Module {
         stop.action = this::close;
 
         WButton guide = list.add(theme.button("Guide")).expandX().widget();
-        guide.action = () -> Util.getOperatingSystem().open("https://github.com/MeteorDevelopment/meteor-client/wiki/Swarm-Guide");
+        guide.action = () -> Util.getOperatingSystem().open("https://github.com/cookie-client/cookie-client/wiki/Swarm-Guide");
 
         return list;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmConnection.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmConnection.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmHost.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmHost.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmWorker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmWorker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AirJump.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AirJump.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Anchor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Anchor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AntiVoid.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AntiVoid.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AutoJump.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AutoJump.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AutoWalk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AutoWalk.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AutoWasp.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/AutoWasp.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Blink.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Blink.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/BoatFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/BoatFly.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ElytraBoost.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ElytraBoost.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntityControl.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntityControl.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/FastClimb.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/FastClimb.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/GUIMove.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/GUIMove.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/HighJump.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/HighJump.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Jesus.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Jesus.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/LongJump.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/LongJump.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoSlow.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoSlow.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Parkour.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Parkour.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ReverseStep.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ReverseStep.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/SafeWalk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/SafeWalk.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Slippy.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Slippy.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sneak.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sneak.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Spider.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Spider.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Step.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Step.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/TridentBoost.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/TridentBoost.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Velocity.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Velocity.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightModes.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightModes.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Packet.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Packet.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Pitch40.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Pitch40.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Vanilla.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Vanilla.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/Speed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/Speed.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/SpeedMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/SpeedMode.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/SpeedModes.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/SpeedModes.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/modes/Strafe.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/modes/Strafe.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/modes/Vanilla.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/modes/Vanilla.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AirPlace.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AirPlace.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiHunger.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiHunger.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoClicker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoClicker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoFish.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoFish.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoMend.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoMend.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoReplenish.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoReplenish.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoRespawn.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoRespawn.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/EXPThrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/EXPThrower.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FakePlayer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FakePlayer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FastUse.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FastUse.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/GhostHand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/GhostHand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/InstantRebreak.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/InstantRebreak.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/LiquidInteract.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/LiquidInteract.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/MiddleClickExtra.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/MiddleClickExtra.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Multitask.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Multitask.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NameProtect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NameProtect.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoInteract.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoInteract.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoMiningTrace.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoMiningTrace.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoRotate.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoRotate.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoStatusEffects.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoStatusEffects.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/OffhandCrash.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/OffhandCrash.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Portals.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Portals.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSaver.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSaver.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Reach.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Reach.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Rotation.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Rotation.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/SpeedMine.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/SpeedMine.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTab.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BlockSelection.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BlockSelection.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Blur.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Blur.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BossStack.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BossStack.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Breadcrumbs.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Breadcrumbs.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BreakIndicators.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BreakIndicators.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/CameraTweaks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/CameraTweaks.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Chams.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Chams.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/CityESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/CityESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/EntityOwner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/EntityOwner.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/FreeLook.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/FreeLook.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Fullbright.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Fullbright.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/HandView.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/HandView.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/HoleESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/HoleESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ItemHighlight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ItemHighlight.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ItemPhysics.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ItemPhysics.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LogoutSpots.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LogoutSpots.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/PopChams.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/PopChams.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/StorageESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/StorageESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/TimeChanger.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/TimeChanger.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Tracers.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Tracers.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trail.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trail.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trajectories.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trajectories.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/TunnelESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/TunnelESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/VoidESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/VoidESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockData.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockData.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockDataScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockDataScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPGroup.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPGroup.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/BaseMarker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/BaseMarker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/CuboidMarker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/CuboidMarker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/Marker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/Marker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/MarkerFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/MarkerFactory.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/Sphere2dMarker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/marker/Sphere2dMarker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Ambience.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Ambience.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBrewer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBrewer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoMount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoMount.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSign.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSign.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSmelter.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSmelter.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/BuildHeight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/BuildHeight.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Collisions.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Collisions.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EChestFarmer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EChestFarmer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EndermanLook.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EndermanLook.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Excavator.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Excavator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/LiquidFiller.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/LiquidFiller.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/MountBypass.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/MountBypass.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/NoGhostBlocks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/NoGhostBlocks.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/PacketMine.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/PacketMine.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/StashFinder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/StashFinder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Timer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Timer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/VeinMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/VeinMiner.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profiles.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profiles.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/ProxyType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/ProxyType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoint.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoints.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoints.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/events/WaypointAddedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/events/WaypointAddedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/events/WaypointRemovedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/events/WaypointRemovedEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/PostInit.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/PostInit.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/PreInit.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/PreInit.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/ReflectInit.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/ReflectInit.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/DamageUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/DamageUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/EntityUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/EntityUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/ProjectileEntitySimulator.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/ProjectileEntitySimulator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/SortPriority.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/SortPriority.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/Target.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/Target.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/TargetUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/TargetUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/fakeplayer/FakePlayerEntity.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/fakeplayer/FakePlayerEntity.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/fakeplayer/FakePlayerManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/fakeplayer/FakePlayerManager.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/files/StreamUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/files/StreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/ByteCountDataOutput.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/ByteCountDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/CPSUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/CPSUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/ComponentMapReader.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/ComponentMapReader.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/CookieStarscript.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/CookieStarscript.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/CursorStyle.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/CursorStyle.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/EmptyIterator.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/EmptyIterator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/FakeClientPlayer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/FakeClientPlayer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/HorizontalDirection.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/HorizontalDirection.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/IChangeable.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/IChangeable.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/ICopyable.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/ICopyable.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/IGetter.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/IGetter.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/ISerializable.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/ISerializable.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Keybind.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Keybind.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MBlockPos.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MBlockPos.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MissHitResult.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MissHitResult.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MyPotion.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MyPotion.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/NbtException.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/NbtException.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/NbtUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/NbtUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Pool.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Pool.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Producer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Producer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/UnorderedArrayList.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/UnorderedArrayList.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/ValueComparableMap.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/ValueComparableMap.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Version.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Version.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/input/Input.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/input/Input.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/input/KeyAction.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/input/KeyAction.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/input/KeyBinds.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/input/KeyBinds.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/ColoredText.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/ColoredText.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/CookieClickEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/CookieClickEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/RunnableClickEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/RunnableClickEvent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextVisitor.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextVisitor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/Capes.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/Capes.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/CookieExecutor.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/CookieExecutor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/FailedHttpResponse.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/FailedHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/Http.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/Http.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/JsonBodyHandler.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/JsonBodyHandler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/OnlinePlayers.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/OnlinePlayers.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 
@@ -15,21 +15,17 @@ public class OnlinePlayers {
         long time = System.currentTimeMillis();
 
         if (time - lastPingTime > 5 * 60 * 1000) {
- ogmq5k-codex/rename-meteor-files-to-cookie
             
 
             MeteorExecutor.execute(() -> Http.post("https://cookieclient.com/api/online/ping").ignoreExceptions().send());
- master
 
             lastPingTime = time;
         }
     }
 
     public static void leave() {
- ogmq5k-codex/rename-meteor-files-to-cookie
         CookieExecutor.execute(() -> Http.post("https://meteorclient.com/api/online/leave").ignoreExceptions().send());
 
        
- master
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/PacketUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/PacketUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client/).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client/).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/PacketUtilsUtil.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/PacketUtilsUtil.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 
@@ -43,7 +43,7 @@ public class PacketUtilsUtil {
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             writer.write("/*\n");
-            writer.write(" * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client/).\n");
+            writer.write(" * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client/).\n");
             writer.write(" * Copyright (c) Cookie Development.\n");
             writer.write(" */\n\n");
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/NotebotUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/NotebotUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/NBSSongDecoder.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/NBSSongDecoder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/SongDecoder.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/SongDecoder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/SongDecoders.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/SongDecoders.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/TextSongDecoder.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/decoder/TextSongDecoder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/instrumentdetect/InstrumentDetectFunction.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/instrumentdetect/InstrumentDetectFunction.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/instrumentdetect/InstrumentDetectMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/instrumentdetect/InstrumentDetectMode.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/song/Note.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/song/Note.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/song/Song.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/song/Song.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/other/JsonDateDeserializer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/other/JsonDateDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/other/Snapper.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/other/Snapper.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/CustomPlayerInput.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/CustomPlayerInput.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/EChestMemory.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/EChestMemory.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/FindItemResult.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/FindItemResult.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InventorySorter.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InventorySorter.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/PathFinder.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/PathFinder.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/Rotations.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/Rotations.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/Safety.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/Safety.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/SlotUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/SlotUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/AlignmentX.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/AlignmentX.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/AlignmentY.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/AlignmentY.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/Box.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/Box.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/CookieToast.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/CookieToast.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/FontUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/FontUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/IVertexConsumerProvider.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/IVertexConsumerProvider.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/MeshBuilderVertexConsumerProvider.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/MeshBuilderVertexConsumerProvider.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/NametagUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/NametagUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/PeekScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/PeekScreen.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/RenderUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/RenderUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/SimpleBlockRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/SimpleBlockRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/WireframeEntityRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/WireframeEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/color/Color.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/color/Color.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/color/RainbowColor.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/color/RainbowColor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/color/RainbowColors.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/color/RainbowColors.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/color/SettingColor.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/color/SettingColor.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/ChamsShader.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/ChamsShader.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/OutlineUniforms.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/OutlineUniforms.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/OkPrompt.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/OkPrompt.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/YesNoPrompt.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/YesNoPrompt.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/BannerTooltipComponent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/BannerTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/BookTooltipComponent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/BookTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/ContainerTooltipComponent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/ContainerTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/CookieTooltipData.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/CookieTooltipData.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/EntityTooltipComponent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/EntityTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/MapTooltipComponent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/MapTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/tooltip/TextTooltipComponent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/tooltip/TextTooltipComponent.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockEntityIterator.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockEntityIterator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockIterator.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockIterator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/CardinalDirection.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/CardinalDirection.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/ChunkIterator.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/ChunkIterator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/Dimension.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/Dimension.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/Dir.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/Dir.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/TickRate.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/TickRate.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Cookie Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
  * Copyright (c) Cookie Development.
  */
 


### PR DESCRIPTION
## Summary
- update Java files with new GitHub URL
- update IDEA copyright template

## Testing
- `./gradlew build --no-daemon` *(fails: cannot find symbol MeteorExecutor)*

------
https://chatgpt.com/codex/tasks/task_e_687e9bea680c83209f7d2bed245bbd55