### PR TITLE
Fix stray markers and build errors

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -110,12 +110,8 @@ public class ESPChunk {
 
         for (int x = chunk.getPos().getStartX(); x <= chunk.getPos().getEndX(); x++) {
             for (int z = chunk.getPos().getStartZ(); z <= chunk.getPos().getEndZ(); z++) {
- k2ci8d-codex/review-build.gradle.kts-dependencies
-                
-
                 int height = chunk.getHeightmap(Heightmap.Type.WORLD_SURFACE)
                     .get(x - chunk.getPos().getStartX(), z - chunk.getPos().getStartZ());
- master
 
                 if (height > maxHeight) maxHeight = height;
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/OnlinePlayers.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/OnlinePlayers.java
@@ -17,7 +17,7 @@ public class OnlinePlayers {
         if (time - lastPingTime > 5 * 60 * 1000) {
             
 
-            MeteorExecutor.execute(() -> Http.post("https://cookieclient.com/api/online/ping").ignoreExceptions().send());
+            CookieExecutor.execute(() -> Http.post("https://cookieclient.com/api/online/ping").ignoreExceptions().send());
 
             lastPingTime = time;
         }


### PR DESCRIPTION
## Summary
- remove stray merge text from ESPChunk
- replace missing `MeteorExecutor` usage with `CookieExecutor`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_687ea431d98c8320918b5d8059ab09cc