### PR TITLE
Fix BlockESP chunk vertical culling

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -124,7 +124,6 @@ public class ESPChunk {
             }
         }
 
-        schunk.top = maxHeight;
 
         return schunk;
     }


### PR DESCRIPTION
## Summary
- stop overriding `ESPChunk.top` with chunk-specific max height

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_687eb12a62948320a0027cba9945562c