### PR TITLE
Increase vertical search range slider

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -75,7 +75,7 @@ public class BlockESP extends Module {
         .description("Additional chunk distance used to search for blocks. Also limits vertical culling range in blocks using this value * 16.")
         .defaultValue(1)
         .min(1)
-        .sliderMax(32)
+        .sliderMax(64)
         .build()
     );
 


### PR DESCRIPTION
## Summary
- allow BlockESP distance slider up to 64

## Testing
- `./gradlew --no-daemon test`

------
https://chatgpt.com/codex/tasks/task_e_687ebbccff508320b2c14da58f55cdc1