### PR TITLE
Fix reach setting not affecting block highlight

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -19,6 +19,7 @@ import meteordevelopment.meteorclient.renderer.Renderer3D;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.player.LiquidInteract;
 import meteordevelopment.meteorclient.systems.modules.player.NoMiningTrace;
+import meteordevelopment.meteorclient.systems.modules.player.Reach;
 import meteordevelopment.meteorclient.systems.modules.render.Freecam;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import meteordevelopment.meteorclient.systems.modules.render.Zoom;
@@ -45,6 +46,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
@@ -143,6 +145,11 @@ public abstract class GameRendererMixin {
         if (original.getType() != HitResult.Type.MISS) return original;
 
         return entity.raycast(maxDistance, tickProgress, true);
+    }
+
+    @ModifyArg(method = "findCrosshairTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;raycast(DFZ)Lnet/minecraft/util/hit/HitResult;"), index = 0)
+    private double modifyRaycastDistance(double distance) {
+        return distance + Modules.get().get(Reach.class).blockReach();
     }
 
     @Inject(method = "showFloatingItem", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
## Summary
- extend the raycast distance in `GameRendererMixin` to include extra reach

## Testing
- `./gradlew build --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_687ec34b22a883208f67f96645847434