### PR TITLE
Add ServerConfigStealer module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Categories.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Categories.java
@@ -16,6 +16,7 @@ public class Categories {
     public static final Category Render = new Category("Render", Items.GLASS.getDefaultStack());
     public static final Category World = new Category("World", Items.GRASS_BLOCK.getDefaultStack());
     public static final Category Misc = new Category("Misc", Items.LAVA_BUCKET.getDefaultStack());
+    public static final Category Utility = new Category("Utility", Items.COMPASS.getDefaultStack());
 
     public static boolean REGISTERING;
 
@@ -29,6 +30,7 @@ public class Categories {
         Modules.registerCategory(Render);
         Modules.registerCategory(World);
         Modules.registerCategory(Misc);
+        Modules.registerCategory(Utility);
 
         // Addons
         AddonManager.ADDONS.forEach(CookieAddon::onRegisterCategories);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -26,6 +26,7 @@ import meteordevelopment.meteorclient.systems.modules.misc.swarm.Swarm;
 import meteordevelopment.meteorclient.systems.modules.movement.*;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
 import meteordevelopment.meteorclient.systems.modules.movement.speed.Speed;
+import meteordevelopment.meteorclient.systems.modules.utility.*;
 import meteordevelopment.meteorclient.systems.modules.player.*;
 import meteordevelopment.meteorclient.systems.modules.render.*;
 import meteordevelopment.meteorclient.systems.modules.render.blockesp.BlockESP;
@@ -76,6 +77,7 @@ public class Modules extends System<Modules> {
         initMovement();
         initRender();
         initWorld();
+        initUtility();
         initMisc();
     }
 
@@ -556,6 +558,10 @@ public class Modules extends System<Modules> {
             add(new Excavator());
             add(new InfinityMiner());
         }
+    }
+
+    private void initUtility() {
+        add(new ServerConfigStealer());
     }
 
     private void initMisc() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/utility/ServerConfigStealer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/utility/ServerConfigStealer.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Cookie Client distribution (https://github.com/cookie-client/cookie-client).
+ * Copyright (c) Cookie Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.utility;
+
+import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
+import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.network.packet.s2c.play.GameMessageS2CPacket;
+
+public class ServerConfigStealer extends Module {
+    public ServerConfigStealer() {
+        super(Categories.Utility, "server-config-stealer", "Attempts to collect public server config info such as version, software, and plugins.");
+    }
+
+    @Override
+    public void onActivate() {
+        sendCmd("/pl");
+        sendCmd("/plugins");
+        sendCmd("/about");
+        sendCmd("/version");
+        sendCmd("/forge");
+        sendCmd("/mods");
+
+        info("Sent info requests. Watch chat for plugin/version info.");
+    }
+
+    private void sendCmd(String cmd) {
+        if (mc.player != null) {
+            ChatUtils.sendPlayerMsg(cmd);
+        }
+    }
+
+    @EventHandler
+    private void onPacketReceive(PacketEvent.Receive event) {
+        if (event.packet instanceof GameMessageS2CPacket packet) {
+            String msg = packet.content().getString();
+            String lower = msg.toLowerCase();
+            if (lower.contains("plugin") || lower.contains("version")) {
+                info("[ServerConfigStealer] " + msg);
+            }
+        }
+    }
+
+    @EventHandler
+    private void onGameJoin(GameJoinedEvent event) {
+        String serverBrand = "unknown";
+        if (mc.getCurrentServerEntry() != null && mc.getCurrentServerEntry().label != null) {
+            serverBrand = mc.getCurrentServerEntry().label.getString();
+        }
+        info("Server Brand: " + serverBrand);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `Utility` category
- support `ServerConfigStealer` module to gather publicly available server info
- register the new module and category

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_687ed83a471c83209bc17efd90b9e553